### PR TITLE
Make comments italicized

### DIFF
--- a/base16-3024.dark.tmTheme
+++ b/base16-3024.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#5c5855</string>
 			</dict>

--- a/base16-3024.light.tmTheme
+++ b/base16-3024.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#807d7c</string>
 			</dict>

--- a/base16-atelierdune.dark.tmTheme
+++ b/base16-atelierdune.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#7d7a68</string>
 			</dict>

--- a/base16-atelierdune.light.tmTheme
+++ b/base16-atelierdune.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#999580</string>
 			</dict>

--- a/base16-atelierforest.dark.tmTheme
+++ b/base16-atelierforest.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#766e6b</string>
 			</dict>

--- a/base16-atelierforest.light.tmTheme
+++ b/base16-atelierforest.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#9c9491</string>
 			</dict>

--- a/base16-atelierheath.dark.tmTheme
+++ b/base16-atelierheath.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#776977</string>
 			</dict>

--- a/base16-atelierheath.light.tmTheme
+++ b/base16-atelierheath.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#9e8f9e</string>
 			</dict>

--- a/base16-atelierlakeside.dark.tmTheme
+++ b/base16-atelierlakeside.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#5a7b8c</string>
 			</dict>

--- a/base16-atelierlakeside.light.tmTheme
+++ b/base16-atelierlakeside.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#7195a8</string>
 			</dict>

--- a/base16-atelierseaside.dark.tmTheme
+++ b/base16-atelierseaside.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#687d68</string>
 			</dict>

--- a/base16-atelierseaside.light.tmTheme
+++ b/base16-atelierseaside.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#809980</string>
 			</dict>

--- a/base16-bespin.dark.tmTheme
+++ b/base16-bespin.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#666666</string>
 			</dict>

--- a/base16-bespin.light.tmTheme
+++ b/base16-bespin.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#797977</string>
 			</dict>

--- a/base16-brewer.dark.tmTheme
+++ b/base16-brewer.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#737475</string>
 			</dict>

--- a/base16-brewer.light.tmTheme
+++ b/base16-brewer.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#959697</string>
 			</dict>

--- a/base16-bright.dark.tmTheme
+++ b/base16-bright.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#b0b0b0</string>
 			</dict>

--- a/base16-bright.light.tmTheme
+++ b/base16-bright.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#d0d0d0</string>
 			</dict>

--- a/base16-chalk.dark.tmTheme
+++ b/base16-chalk.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#505050</string>
 			</dict>

--- a/base16-chalk.light.tmTheme
+++ b/base16-chalk.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#b0b0b0</string>
 			</dict>

--- a/base16-default.dark.tmTheme
+++ b/base16-default.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#505050</string>
 			</dict>

--- a/base16-default.light.tmTheme
+++ b/base16-default.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#b0b0b0</string>
 			</dict>

--- a/base16-eighties.dark.tmTheme
+++ b/base16-eighties.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#747369</string>
 			</dict>

--- a/base16-eighties.light.tmTheme
+++ b/base16-eighties.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#a09f93</string>
 			</dict>

--- a/base16-flat.dark.tmTheme
+++ b/base16-flat.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#95A5A6</string>
 			</dict>

--- a/base16-flat.light.tmTheme
+++ b/base16-flat.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#BDC3C7</string>
 			</dict>

--- a/base16-google.dark.tmTheme
+++ b/base16-google.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#969896</string>
 			</dict>

--- a/base16-google.light.tmTheme
+++ b/base16-google.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#b4b7b4</string>
 			</dict>

--- a/base16-grayscale.dark.tmTheme
+++ b/base16-grayscale.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#525252</string>
 			</dict>

--- a/base16-grayscale.light.tmTheme
+++ b/base16-grayscale.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#ababab</string>
 			</dict>

--- a/base16-greenscreen.dark.tmTheme
+++ b/base16-greenscreen.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#007700</string>
 			</dict>

--- a/base16-greenscreen.light.tmTheme
+++ b/base16-greenscreen.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#009900</string>
 			</dict>

--- a/base16-isotope.dark.tmTheme
+++ b/base16-isotope.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#808080</string>
 			</dict>

--- a/base16-isotope.light.tmTheme
+++ b/base16-isotope.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#c0c0c0</string>
 			</dict>

--- a/base16-londontube.dark.tmTheme
+++ b/base16-londontube.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#737171</string>
 			</dict>

--- a/base16-londontube.light.tmTheme
+++ b/base16-londontube.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#959ca1</string>
 			</dict>

--- a/base16-marrakesh.dark.tmTheme
+++ b/base16-marrakesh.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#6c6823</string>
 			</dict>

--- a/base16-marrakesh.light.tmTheme
+++ b/base16-marrakesh.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#86813b</string>
 			</dict>

--- a/base16-mocha.dark.tmTheme
+++ b/base16-mocha.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#7e705a</string>
 			</dict>

--- a/base16-mocha.light.tmTheme
+++ b/base16-mocha.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#b8afad</string>
 			</dict>

--- a/base16-monokai.dark.tmTheme
+++ b/base16-monokai.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#75715e</string>
 			</dict>

--- a/base16-monokai.light.tmTheme
+++ b/base16-monokai.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#a59f85</string>
 			</dict>

--- a/base16-ocean.dark.tmTheme
+++ b/base16-ocean.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#65737e</string>
 			</dict>

--- a/base16-ocean.light.tmTheme
+++ b/base16-ocean.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#a7adba</string>
 			</dict>

--- a/base16-paraiso.dark.tmTheme
+++ b/base16-paraiso.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#776e71</string>
 			</dict>

--- a/base16-paraiso.light.tmTheme
+++ b/base16-paraiso.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#8d8687</string>
 			</dict>

--- a/base16-pop.dark.tmTheme
+++ b/base16-pop.dark.tmTheme
@@ -58,6 +58,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#505050</string>
 			</dict>

--- a/base16-pop.light.tmTheme
+++ b/base16-pop.light.tmTheme
@@ -58,6 +58,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#b0b0b0</string>
 			</dict>

--- a/base16-railscasts.dark.tmTheme
+++ b/base16-railscasts.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#5a647e</string>
 			</dict>

--- a/base16-railscasts.light.tmTheme
+++ b/base16-railscasts.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#d4cfc9</string>
 			</dict>

--- a/base16-shapeshifter.dark.tmTheme
+++ b/base16-shapeshifter.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#343434</string>
 			</dict>

--- a/base16-shapeshifter.light.tmTheme
+++ b/base16-shapeshifter.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#555555</string>
 			</dict>

--- a/base16-solarized.dark.tmTheme
+++ b/base16-solarized.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#657b83</string>
 			</dict>

--- a/base16-solarized.light.tmTheme
+++ b/base16-solarized.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#839496</string>
 			</dict>

--- a/base16-tomorrow.dark.tmTheme
+++ b/base16-tomorrow.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#969896</string>
 			</dict>

--- a/base16-tomorrow.light.tmTheme
+++ b/base16-tomorrow.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#b4b7b4</string>
 			</dict>

--- a/base16-twilight.dark.tmTheme
+++ b/base16-twilight.dark.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#5f5a60</string>
 			</dict>

--- a/base16-twilight.light.tmTheme
+++ b/base16-twilight.light.tmTheme
@@ -60,6 +60,8 @@
 			<string>comment, punctuation.definition.comment</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 				<key>foreground</key>
 				<string>#838184</string>
 			</dict>


### PR DESCRIPTION
I find it much easier to read all of my code when the comments are italicized. This pull request italicizes comments in all of the themes  so that they are easily separable from the actual code.

I've been doing this myself each time an update comes out, but it's a bit tedious... thus this pull request.
