### PR TITLE
Color operators like `$`, `+` and `=`

### DIFF
--- a/base16-eighties.dark.tmTheme
+++ b/base16-eighties.dark.tmTheme
@@ -94,7 +94,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#d3d0c8</string>
+				<string>#cc99cc</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
This change particularly helps in JavaScript where `+` is frequently used for string interpolation and jQuery which makes liberal use of `$`. This change also makes the theme more consistent with other highlighters that colorize this scope.

Before
![7b61c3d0-c5d8-11e4-8391-7f8f9b01aa5f](https://cloud.githubusercontent.com/assets/498744/6702088/6e635c9a-ccfc-11e4-8527-0284ae8efcaf.png)

After
![7e8cca3c-c5d8-11e4-9401-1f68864a87cb](https://cloud.githubusercontent.com/assets/498744/6702089/6e66a88c-ccfc-11e4-8e8d-7781a4c0318b.png)
