### PR TITLE
Added highlighting for Markdown punctuation beginning (punctuation.de…

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -360,7 +360,7 @@
 			<key>name</key>
 			<string>Link Text</string>
 			<key>scope</key>
-      <string>string.other.link, punctuation.definition.string.end.markdown</string>
+      <string>string.other.link, punctuation.definition.string.end.markdown, punctuation.definition.string.begin.markdown</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>


### PR DESCRIPTION
…finition.string.begin.markdown).

The missing highlighting was evident in eg. `[link text](https://www.github.com)`.